### PR TITLE
Dual Queue PoC

### DIFF
--- a/x/ibc-rate-limit/contracts/rate-limiter/src/contract.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/contract.rs
@@ -59,6 +59,13 @@ pub fn execute(
             quota_id,
             env.block.time,
         ),
+        ExecuteMsg::BypassUpdate { sender, channel_id, denom, amount } => execute::bypass_update(
+            deps,
+            sender,
+            channel_id,
+            denom,
+            amount
+        )
     }
 }
 

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/contract.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/contract.rs
@@ -61,6 +61,7 @@ pub fn execute(
         ),
         ExecuteMsg::BypassUpdate { sender, channel_id, denom, amount } => execute::bypass_update(
             deps,
+            info.sender,
             sender,
             channel_id,
             denom,
@@ -71,12 +72,12 @@ pub fn execute(
             channel_id,
             denom,
             amount
-        } => execute::submit_intent(deps, env, sender, channel_id, denom, amount),
+        } => execute::submit_intent(deps, env, info.sender, sender, channel_id, denom, amount),
         ExecuteMsg::RemoveIntent {
             sender,
             channel_id,
             denom
-        } => execute::remove_intent(deps,  sender, channel_id, denom)
+        } => execute::remove_intent(deps,  info.sender, sender, channel_id, denom)
     }
 }
 

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/contract.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/contract.rs
@@ -65,7 +65,18 @@ pub fn execute(
             channel_id,
             denom,
             amount
-        )
+        ),
+        ExecuteMsg::SubmitIntent {
+            sender,
+            channel_id,
+            denom,
+            amount
+        } => execute::submit_intent(deps, env, sender, channel_id, denom, amount),
+        ExecuteMsg::RemoveIntent {
+            sender,
+            channel_id,
+            denom
+        } => execute::remove_intent(deps,  sender, channel_id, denom)
     }
 }
 

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/error.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/error.rs
@@ -26,4 +26,6 @@ pub enum ContractError {
         channel_id: String,
         denom: String,
     },
+    #[error("more tokens than allowed attempted to be transferred")]
+    InsufficientBypassAllowance,
 }

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/error.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/error.rs
@@ -32,4 +32,6 @@ pub enum ContractError {
     IntentAlreadyPresent,
     #[error("no intent matching (sender, channel_id, denom) is present")]
     IntentNotPresent,
+    #[error("the amount of is less than the threshold of {0}")]
+    InsufficientBypassAmount(u8),
 }

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/error.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/error.rs
@@ -30,4 +30,6 @@ pub enum ContractError {
     InsufficientBypassAllowance,
     #[error("only one intent per (sender, channel_id, denom) may be present")]
     IntentAlreadyPresent,
+    #[error("no intent matching (sender, channel_id, denom) is present")]
+    IntentNotPresent,
 }

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/error.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/error.rs
@@ -28,4 +28,6 @@ pub enum ContractError {
     },
     #[error("more tokens than allowed attempted to be transferred")]
     InsufficientBypassAllowance,
+    #[error("only one intent per (sender, channel_id, denom) may be present")]
+    IntentAlreadyPresent,
 }

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/execute.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/execute.rs
@@ -117,11 +117,17 @@ pub fn try_reset_path_quota(
 /// to "remove" an address from the bypass queue you can set `amount == 0`
 pub fn bypass_update(
     deps: DepsMut,
+    msg_invoker: Addr,
     sender: Addr,
     channel_id: String,
     denom: String,
     amount: Uint256,
 ) -> Result<Response, ContractError> {
+    let ibc_module = IBCMODULE.load(deps.storage)?;
+    let gov_module = GOVMODULE.load(deps.storage)?;
+    if msg_invoker != ibc_module && msg_invoker != gov_module {
+        return Err(ContractError::Unauthorized {});
+    }
     let sender = sender.to_string();
     let path = &Path::new(channel_id, denom);
     let mut bypass_queue = TEMPORARY_RATE_LIMIT_BYPASS
@@ -153,11 +159,18 @@ pub fn bypass_update(
 pub fn submit_intent(
     deps: DepsMut,
     env: Env,
+    msg_invoker: Addr,
     sender: Addr,
     channel_id: String,
     denom: String,
     amount: Uint256,
 ) -> Result<Response, ContractError> {
+    let ibc_module = IBCMODULE.load(deps.storage)?;
+    let gov_module = GOVMODULE.load(deps.storage)?;
+    if msg_invoker != ibc_module && msg_invoker != gov_module {
+        return Err(ContractError::Unauthorized {});
+    }
+
     // unlock time is the current block time plus 24 hours (86400 seconds)
     let unlock_time = env.block.time.plus_seconds(86400);
 
@@ -196,10 +209,17 @@ pub fn submit_intent(
 /// removes an intent from the intent queue
 pub fn remove_intent(
     deps: DepsMut,
+    msg_invoker: Addr,
     sender: Addr,
     channel_id: String,
     denom: String,
 ) -> Result<Response, ContractError> {
+    let ibc_module = IBCMODULE.load(deps.storage)?;
+    let gov_module = GOVMODULE.load(deps.storage)?;
+    if msg_invoker != ibc_module && msg_invoker != gov_module {
+        return Err(ContractError::Unauthorized {});
+    }
+    
     let path = &Path::new(channel_id, denom);
 
     if INTENT_QUEUE.has(

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/execute.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/execute.rs
@@ -176,7 +176,7 @@ pub fn submit_intent(
     let mut threshold: Option<Uint256> = None;
     // minimum threshold of the channel value that can be used in a bypass
     const MIN_THRESHOLD: u8 = 25;
-    // when setting a bypass entry to a non zero value check to see if its MIN_THRESHOLD or greater than the rate limits
+    // when submitting an intent  require that its  MIN_THRESHOLD or greater than the rate limits
     // channel_value for the daily tracker
     //
     // if no daily tracker is present  then threshold evaluation does not occur

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/execute_tests.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/execute_tests.rs
@@ -30,7 +30,7 @@ fn test_bypass_update_no_threshold() {
     let channel_id =format!("channel");
     let denom = format!("denom");
     let sender = Addr::unchecked("SENDER_ADDR");
-    let res = bypass_update(deps.as_mut(), mock_env().block.time, Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
+    let res = bypass_update(deps.as_mut(), Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
     assert_eq!(res.attributes[0].key, "sender_bypass");
     assert_eq!(res.attributes[0].value, sender.to_string());
 
@@ -122,7 +122,7 @@ fn test_bypass_update_to_zero() {
     let channel_id =format!("channel");
     let denom = format!("denom");
     let sender = Addr::unchecked("SENDER_ADDR");
-    let res = bypass_update(deps.as_mut(), mock_env().block.time, Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
+    let res = bypass_update(deps.as_mut(),  Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
     assert_eq!(res.attributes[0].key, "sender_bypass");
     assert_eq!(res.attributes[0].value, sender.to_string());
 
@@ -131,7 +131,7 @@ fn test_bypass_update_to_zero() {
     assert_eq!(bypass_queue[0].0, sender.to_string());
     assert_eq!(bypass_queue[0].1, Uint256::from_u128(100));
 
-    let res = bypass_update(deps.as_mut(), mock_env().block.time, Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::zero()).unwrap();
+    let res = bypass_update(deps.as_mut(), Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::zero()).unwrap();
     assert_eq!(res.attributes[0].key, "sender_bypass");
     assert_eq!(res.attributes[0].value, sender.to_string());
 

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/execute_tests.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/execute_tests.rs
@@ -1,39 +1,20 @@
 #![cfg(test)]
 
 use crate::execute::{bypass_update, submit_intent, intent_ok, remove_intent};
-use crate::packet::Packet;
-use crate::{contract::*, test_msg_recv, test_msg_send, ContractError};
+use crate::contract::*;
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-use cosmwasm_std::{from_binary, Addr, Attribute, Uint256, Coin, Uint128, Timestamp};
-use cw_multi_test::{App, AppBuilder};
+use cosmwasm_std::{ Addr,  Uint256, Timestamp};
 
-use crate::helpers::tests::verify_query_response;
-use crate::msg::{InstantiateMsg, PathMsg, QueryMsg, QuotaMsg, SudoMsg};
-use crate::state::tests::RESET_TIME_WEEKLY;
-use crate::state::{RateLimit, GOVMODULE, IBCMODULE, RATE_LIMIT_TRACKERS, TEMPORARY_RATE_LIMIT_BYPASS, INTENT_QUEUE};
+use crate::msg::{InstantiateMsg, PathMsg, QuotaMsg};
+use crate::state::tests::{RESET_TIME_WEEKLY, RESET_TIME_DAILY};
+use crate::state::{RATE_LIMIT_TRACKERS, TEMPORARY_RATE_LIMIT_BYPASS, INTENT_QUEUE, Path};
 
 const IBC_ADDR: &str = "IBC_MODULE";
 const GOV_ADDR: &str = "GOV_MODULE";
 
-fn mock_app() -> App {
-    AppBuilder::new().build(|router, _, storage| {
-        router
-            .bank
-            .init_balance(
-                storage,
-                &Addr::unchecked("USER"),
-                vec![Coin {
-                    denom: "nosmo".to_string(),
-                    amount: Uint128::new(1_000),
-                }],
-            )
-            .unwrap();
-    })
-}
-
 
 #[test] // Tests we ccan instantiate the contract and that the owners are set correctly
-fn test_bypass_update() {
+fn test_bypass_update_no_threshold() {
     let mut deps = mock_dependencies();
 
     let msg = InstantiateMsg {
@@ -49,7 +30,7 @@ fn test_bypass_update() {
     let channel_id =format!("channel");
     let denom = format!("denom");
     let sender = Addr::unchecked("SENDER_ADDR");
-    let res = bypass_update(deps.as_mut(), Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
+    let res = bypass_update(deps.as_mut(), mock_env().block.time, Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
     assert_eq!(res.attributes[0].key, "sender_bypass");
     assert_eq!(res.attributes[0].value, sender.to_string());
 
@@ -60,9 +41,73 @@ fn test_bypass_update() {
 }
 
 #[test]
+fn test_submit_intent_threshold() {
+    let mut deps = mock_dependencies();
+    let mut env = mock_env();
+    env.block.time = Timestamp::from_seconds(1700553596);
+    let quota_daily = QuotaMsg::new("daily", RESET_TIME_DAILY, 30, 40);
+    let quota_weekly = QuotaMsg::new("weekly", RESET_TIME_WEEKLY, 30, 40);
+    let msg = InstantiateMsg {
+        gov_module: Addr::unchecked(GOV_ADDR),
+        ibc_module: Addr::unchecked(IBC_ADDR),
+        paths: vec![PathMsg {
+            channel_id: format!("any"),
+            denom: format!("denom"),
+            quotas: vec![quota_daily.clone(), quota_weekly.clone()],
+        }],
+    };
+    let info = mock_info(IBC_ADDR, &vec![]);
+    let path = &Path::new("any", "denom");
+    let _ = instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
+
+    {
+        let mut trackers = RATE_LIMIT_TRACKERS.load(
+            &deps.storage,
+            path.into()
+        ).unwrap();
+        trackers.iter_mut().for_each(|tracker| {
+            tracker.quota.channel_value = Some(Uint256::from_u128(
+                1_000_000_000
+            ));
+        });
+        RATE_LIMIT_TRACKERS.save(
+            &mut deps.storage,
+            path.into(),
+            &trackers
+        ).unwrap();
+    }
+    let threshold = Uint256::from_u128(250000000);
+    let not_threshold = threshold - Uint256::one();
+
+    let channel_id =format!("any");
+    let denom = format!("denom");
+    let sender = Addr::unchecked("SENDER_ADDR");
+
+
+    submit_intent(
+        deps.as_mut(),
+        env.clone(),
+        Addr::unchecked(GOV_ADDR),
+        sender.clone(),
+        channel_id.clone(),
+        denom.clone(),
+        threshold
+    ).unwrap();
+
+    assert!(submit_intent(
+        deps.as_mut(),
+        env.clone(),
+        Addr::unchecked(GOV_ADDR),
+        sender.clone(),
+        channel_id.clone(),
+        denom.clone(),
+        not_threshold
+    ).is_err());
+}
+
+#[test]
 fn test_bypass_update_to_zero() {
     let mut deps = mock_dependencies();
-
     let msg = InstantiateMsg {
         gov_module: Addr::unchecked(GOV_ADDR),
         ibc_module: Addr::unchecked(IBC_ADDR),
@@ -72,11 +117,12 @@ fn test_bypass_update_to_zero() {
 
     // we can just call .unwrap() to assert this was a success
     let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
     assert_eq!(0, res.messages.len());
     let channel_id =format!("channel");
     let denom = format!("denom");
     let sender = Addr::unchecked("SENDER_ADDR");
-    let res = bypass_update(deps.as_mut(), Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
+    let res = bypass_update(deps.as_mut(), mock_env().block.time, Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
     assert_eq!(res.attributes[0].key, "sender_bypass");
     assert_eq!(res.attributes[0].value, sender.to_string());
 
@@ -85,7 +131,7 @@ fn test_bypass_update_to_zero() {
     assert_eq!(bypass_queue[0].0, sender.to_string());
     assert_eq!(bypass_queue[0].1, Uint256::from_u128(100));
 
-    let res = bypass_update(deps.as_mut(), Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::zero()).unwrap();
+    let res = bypass_update(deps.as_mut(), mock_env().block.time, Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::zero()).unwrap();
     assert_eq!(res.attributes[0].key, "sender_bypass");
     assert_eq!(res.attributes[0].value, sender.to_string());
 

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/execute_tests.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/execute_tests.rs
@@ -1,18 +1,36 @@
 #![cfg(test)]
 
-use crate::execute::bypass_update;
+use crate::execute::{bypass_update, submit_intent, intent_ok, remove_intent};
 use crate::packet::Packet;
 use crate::{contract::*, test_msg_recv, test_msg_send, ContractError};
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-use cosmwasm_std::{from_binary, Addr, Attribute, Uint256};
+use cosmwasm_std::{from_binary, Addr, Attribute, Uint256, Coin, Uint128, Timestamp};
+use cw_multi_test::{App, AppBuilder};
 
 use crate::helpers::tests::verify_query_response;
 use crate::msg::{InstantiateMsg, PathMsg, QueryMsg, QuotaMsg, SudoMsg};
 use crate::state::tests::RESET_TIME_WEEKLY;
-use crate::state::{RateLimit, GOVMODULE, IBCMODULE, RATE_LIMIT_TRACKERS, TEMPORARY_RATE_LIMIT_BYPASS};
+use crate::state::{RateLimit, GOVMODULE, IBCMODULE, RATE_LIMIT_TRACKERS, TEMPORARY_RATE_LIMIT_BYPASS, INTENT_QUEUE};
 
 const IBC_ADDR: &str = "IBC_MODULE";
 const GOV_ADDR: &str = "GOV_MODULE";
+
+fn mock_app() -> App {
+    AppBuilder::new().build(|router, _, storage| {
+        router
+            .bank
+            .init_balance(
+                storage,
+                &Addr::unchecked("USER"),
+                vec![Coin {
+                    denom: "nosmo".to_string(),
+                    amount: Uint128::new(1_000),
+                }],
+            )
+            .unwrap();
+    })
+}
+
 
 #[test] // Tests we ccan instantiate the contract and that the owners are set correctly
 fn test_bypass_update() {
@@ -76,4 +94,75 @@ fn test_bypass_update_to_zero() {
     assert_eq!(bypass_queue[0].0, sender.to_string());
     assert_eq!(bypass_queue[0].1, Uint256::zero());
 
+}
+
+#[test]
+fn test_submit_intent() {
+    let mut deps = mock_dependencies();
+    let mut env = mock_env();
+
+    let msg = InstantiateMsg {
+        gov_module: Addr::unchecked(GOV_ADDR),
+        ibc_module: Addr::unchecked(IBC_ADDR),
+        paths: vec![],
+    };
+
+    let channel_id = format!("channel_id");
+    let denom = format!("denom");
+    let sender = Addr::unchecked("SENDER");
+
+    let info = mock_info(IBC_ADDR, &vec![]);
+    
+    let res = instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
+
+    env.block.time = Timestamp::from_seconds(1700383122);
+
+    assert_eq!(0, res.messages.len());
+    let res = submit_intent(
+        deps.as_mut(),
+        env.clone(),
+        sender.clone(),
+        channel_id,
+        denom,
+        Uint256::from_u128(1_000_000)
+    ).unwrap();
+
+    assert_eq!(res.attributes[0].key, "submit_intent");
+    assert_eq!(res.attributes[0].value, sender.to_string());
+    assert_eq!(res.attributes[1].key, "amount");
+    assert_eq!(res.attributes[1].value, Uint256::from_u128(1_000_000).to_string());
+    assert_eq!(res.attributes[2].key, "channel_id");
+    assert_eq!(res.attributes[2].value, "channel_id");
+    assert_eq!(res.attributes[3].key, "denom");
+    assert_eq!(res.attributes[3].value, "denom");
+    assert_eq!(res.attributes[4].key, "intent_action");
+    assert_eq!(res.attributes[4].value, "submit");
+
+
+    let intent = INTENT_QUEUE.load(&deps.storage, (sender.to_string(), "channel_id".to_string(), "denom".to_string())).unwrap();
+    assert_eq!(intent.0, Uint256::from_u128(1_000_000));
+    assert_eq!(intent.1, env.block.time.plus_seconds(86400));
+
+    assert!(!intent_ok(intent, env.block.time, Uint256::from_u128(1_000_000)));
+
+    env.block.time = env.block.time.plus_seconds(86400);
+
+    assert!(intent_ok(intent, env.block.time, Uint256::from_u128(1_000_000)));
+
+    assert!(submit_intent(deps.as_mut(), env.clone(), sender.clone(), "channel_id".to_string(), "denom".to_string(), Uint256::from_u128(1_000_000)).is_err());
+
+    let intent = remove_intent(deps.as_mut(),  sender.clone(), "channel_id".to_string(), "denom".to_string()).unwrap();
+
+    assert_eq!(intent.attributes[0].key, "remove_intent");
+    assert_eq!(intent.attributes[0].value, sender.to_string());
+    assert_eq!(intent.attributes[1].key, "channel_id");
+    assert_eq!(intent.attributes[1].value, "channel_id");
+    assert_eq!(intent.attributes[2].key, "denom");
+    assert_eq!(intent.attributes[2].value, "denom");
+    assert_eq!(intent.attributes[3].key, "intent_action");
+    assert_eq!(intent.attributes[3].value, "remove");
+
+    assert!(remove_intent(deps.as_mut(),  sender.clone(), "channel_id".to_string(), "denom".to_string()).is_err());
+
+    assert!(INTENT_QUEUE.load(&deps.storage, (sender.to_string(), "channel_id".to_string(), "denom".to_string())).is_err());
 }

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/execute_tests.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/execute_tests.rs
@@ -1,0 +1,79 @@
+#![cfg(test)]
+
+use crate::execute::bypass_update;
+use crate::packet::Packet;
+use crate::{contract::*, test_msg_recv, test_msg_send, ContractError};
+use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+use cosmwasm_std::{from_binary, Addr, Attribute, Uint256};
+
+use crate::helpers::tests::verify_query_response;
+use crate::msg::{InstantiateMsg, PathMsg, QueryMsg, QuotaMsg, SudoMsg};
+use crate::state::tests::RESET_TIME_WEEKLY;
+use crate::state::{RateLimit, GOVMODULE, IBCMODULE, RATE_LIMIT_TRACKERS, TEMPORARY_RATE_LIMIT_BYPASS};
+
+const IBC_ADDR: &str = "IBC_MODULE";
+const GOV_ADDR: &str = "GOV_MODULE";
+
+#[test] // Tests we ccan instantiate the contract and that the owners are set correctly
+fn test_bypass_update() {
+    let mut deps = mock_dependencies();
+
+    let msg = InstantiateMsg {
+        gov_module: Addr::unchecked(GOV_ADDR),
+        ibc_module: Addr::unchecked(IBC_ADDR),
+        paths: vec![],
+    };
+    let info = mock_info(IBC_ADDR, &vec![]);
+
+    // we can just call .unwrap() to assert this was a success
+    let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+    assert_eq!(0, res.messages.len());
+    let channel_id =format!("channel");
+    let denom = format!("denom");
+    let sender = Addr::unchecked("SENDER_ADDR");
+    let res = bypass_update(deps.as_mut(), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
+    assert_eq!(res.attributes[0].key, "sender_bypass");
+    assert_eq!(res.attributes[0].value, sender.to_string());
+
+    let bypass_queue = TEMPORARY_RATE_LIMIT_BYPASS.may_load(&deps.storage, (channel_id, denom)).unwrap().unwrap();
+    assert!(bypass_queue.len() == 1);
+    assert_eq!(bypass_queue[0].0, sender.to_string());
+    assert_eq!(bypass_queue[0].1, Uint256::from_u128(100));
+}
+
+#[test]
+fn test_bypass_update_to_zero() {
+    let mut deps = mock_dependencies();
+
+    let msg = InstantiateMsg {
+        gov_module: Addr::unchecked(GOV_ADDR),
+        ibc_module: Addr::unchecked(IBC_ADDR),
+        paths: vec![],
+    };
+    let info = mock_info(IBC_ADDR, &vec![]);
+
+    // we can just call .unwrap() to assert this was a success
+    let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+    assert_eq!(0, res.messages.len());
+    let channel_id =format!("channel");
+    let denom = format!("denom");
+    let sender = Addr::unchecked("SENDER_ADDR");
+    let res = bypass_update(deps.as_mut(), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
+    assert_eq!(res.attributes[0].key, "sender_bypass");
+    assert_eq!(res.attributes[0].value, sender.to_string());
+
+    let bypass_queue = TEMPORARY_RATE_LIMIT_BYPASS.may_load(&deps.storage, (channel_id.clone(), denom.clone())).unwrap().unwrap();
+    assert!(bypass_queue.len() == 1);
+    assert_eq!(bypass_queue[0].0, sender.to_string());
+    assert_eq!(bypass_queue[0].1, Uint256::from_u128(100));
+
+    let res = bypass_update(deps.as_mut(), sender.clone(), channel_id.clone(), denom.clone(), Uint256::zero()).unwrap();
+    assert_eq!(res.attributes[0].key, "sender_bypass");
+    assert_eq!(res.attributes[0].value, sender.to_string());
+
+    let bypass_queue = TEMPORARY_RATE_LIMIT_BYPASS.may_load(&deps.storage, (channel_id, denom)).unwrap().unwrap();
+    assert!(bypass_queue.len() == 1);
+    assert_eq!(bypass_queue[0].0, sender.to_string());
+    assert_eq!(bypass_queue[0].1, Uint256::zero());
+
+}

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/execute_tests.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/execute_tests.rs
@@ -49,7 +49,7 @@ fn test_bypass_update() {
     let channel_id =format!("channel");
     let denom = format!("denom");
     let sender = Addr::unchecked("SENDER_ADDR");
-    let res = bypass_update(deps.as_mut(), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
+    let res = bypass_update(deps.as_mut(), Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
     assert_eq!(res.attributes[0].key, "sender_bypass");
     assert_eq!(res.attributes[0].value, sender.to_string());
 
@@ -76,7 +76,7 @@ fn test_bypass_update_to_zero() {
     let channel_id =format!("channel");
     let denom = format!("denom");
     let sender = Addr::unchecked("SENDER_ADDR");
-    let res = bypass_update(deps.as_mut(), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
+    let res = bypass_update(deps.as_mut(), Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::from_u128(100)).unwrap();
     assert_eq!(res.attributes[0].key, "sender_bypass");
     assert_eq!(res.attributes[0].value, sender.to_string());
 
@@ -85,7 +85,7 @@ fn test_bypass_update_to_zero() {
     assert_eq!(bypass_queue[0].0, sender.to_string());
     assert_eq!(bypass_queue[0].1, Uint256::from_u128(100));
 
-    let res = bypass_update(deps.as_mut(), sender.clone(), channel_id.clone(), denom.clone(), Uint256::zero()).unwrap();
+    let res = bypass_update(deps.as_mut(), Addr::unchecked(GOV_ADDR), sender.clone(), channel_id.clone(), denom.clone(), Uint256::zero()).unwrap();
     assert_eq!(res.attributes[0].key, "sender_bypass");
     assert_eq!(res.attributes[0].value, sender.to_string());
 
@@ -121,6 +121,7 @@ fn test_submit_intent() {
     let res = submit_intent(
         deps.as_mut(),
         env.clone(),
+        Addr::unchecked(GOV_ADDR),
         sender.clone(),
         channel_id,
         denom,
@@ -149,9 +150,9 @@ fn test_submit_intent() {
 
     assert!(intent_ok(intent, env.block.time, Uint256::from_u128(1_000_000)));
 
-    assert!(submit_intent(deps.as_mut(), env.clone(), sender.clone(), "channel_id".to_string(), "denom".to_string(), Uint256::from_u128(1_000_000)).is_err());
+    assert!(submit_intent(deps.as_mut(), env.clone(),Addr::unchecked(GOV_ADDR), sender.clone(), "channel_id".to_string(), "denom".to_string(), Uint256::from_u128(1_000_000)).is_err());
 
-    let intent = remove_intent(deps.as_mut(),  sender.clone(), "channel_id".to_string(), "denom".to_string()).unwrap();
+    let intent = remove_intent(deps.as_mut(),  Addr::unchecked(GOV_ADDR), sender.clone(), "channel_id".to_string(), "denom".to_string()).unwrap();
 
     assert_eq!(intent.attributes[0].key, "remove_intent");
     assert_eq!(intent.attributes[0].value, sender.to_string());
@@ -162,7 +163,7 @@ fn test_submit_intent() {
     assert_eq!(intent.attributes[3].key, "intent_action");
     assert_eq!(intent.attributes[3].value, "remove");
 
-    assert!(remove_intent(deps.as_mut(),  sender.clone(), "channel_id".to_string(), "denom".to_string()).is_err());
+    assert!(remove_intent(deps.as_mut(),  Addr::unchecked(GOV_ADDR), sender.clone(), "channel_id".to_string(), "denom".to_string()).is_err());
 
     assert!(INTENT_QUEUE.load(&deps.storage, (sender.to_string(), "channel_id".to_string(), "denom".to_string())).is_err());
 }

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/lib.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/lib.rs
@@ -17,5 +17,6 @@ mod sudo;
 mod contract_tests;
 mod helpers;
 mod integration_tests;
+mod execute_tests;
 
 pub use crate::error::ContractError;

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/lib.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/lib.rs
@@ -8,6 +8,8 @@ mod state;
 
 pub mod packet;
 
+pub mod utils;
+
 // Functions
 mod execute;
 mod query;

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/msg.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/msg.rs
@@ -75,6 +75,12 @@ pub enum ExecuteMsg {
         denom: String,
         quota_id: String,
     },
+    BypassUpdate {
+        sender: Addr,
+        channel_id: String,
+        denom: String,
+        amount: cosmwasm_std::Uint256
+    }
 }
 
 #[cw_serde]

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/msg.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/msg.rs
@@ -80,6 +80,20 @@ pub enum ExecuteMsg {
         channel_id: String,
         denom: String,
         amount: cosmwasm_std::Uint256
+    },
+    /// used to submit an intent to transfer a large amount of funds that bypasses the rate limit tracker
+    /// submitted intents are delayed for 24 hours allowing governance actions to rever the intent
+    SubmitIntent {
+        sender: Addr,
+        channel_id: String,
+        denom: String,
+        amount: cosmwasm_std::Uint256
+    },
+    /// removes a previously submitted intent preventing it from being used
+    RemoveIntent {
+        sender: Addr,
+        channel_id: String,
+        denom: String,
     }
 }
 

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/packet.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/packet.rs
@@ -184,6 +184,11 @@ impl Packet {
     pub fn path_data(&self, direction: &FlowType) -> (String, String) {
         (self.local_channel(direction), self.local_denom(direction))
     }
+
+    /// returns the address that was responsibnle for originating this ibc transfer
+    pub fn sender(&self) -> Addr {
+        self.data.sender.clone()
+    }
 }
 
 // Helpers

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/state.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/state.rs
@@ -338,6 +338,9 @@ pub const RATE_LIMIT_TRACKERS: Map<(String, String), Vec<RateLimit>> = Map::new(
 /// maps (ibc_channel, denom) => sender => amount 
 pub const TEMPORARY_RATE_LIMIT_BYPASS: Map<(String, String), Vec<(String, Uint256)>> = Map::new("bypass");
 
+/// Intent Queue allows for users to submit intents to transfer an amount bypassing the rate limit tracker evaluation after a delayed period of time
+pub const INTENT_QUEUE: Map<(String, String, String), (Uint256, Timestamp)> = Map::new("intent");
+
 
 #[cfg(test)]
 pub mod tests {

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/state.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/state.rs
@@ -336,13 +336,7 @@ pub const RATE_LIMIT_TRACKERS: Map<(String, String), Vec<RateLimit>> = Map::new(
 /// Indicates accounts that can bypass a rate limit for a specific IBC Channel + denom, and the amount that can be sent
 /// 
 /// maps (ibc_channel, denom) => sender => amount 
-pub const TEMPORARY_RATE_LIMIT_BYPASS: Map<(String, String), HashMap<String, Uint256>> = Map::new("bypass");
-
-/// BypassQueue is a workaround for the `Map` storage type not support
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
-pub struct BypassQueue {
-    pub entries: HashMap<String, Uint256>
-}
+pub const TEMPORARY_RATE_LIMIT_BYPASS: Map<(String, String), Vec<(String, Uint256)>> = Map::new("bypass");
 
 
 #[cfg(test)]

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/state.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/state.rs
@@ -1,9 +1,9 @@
 use cosmwasm_std::{Addr, Timestamp, Uint256};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::cmp;
+use std::{cmp, collections::HashMap};
 
-use cw_storage_plus::{Item, Map};
+use cw_storage_plus::{Item, Map, Deque};
 
 use crate::{msg::QuotaMsg, ContractError};
 
@@ -331,6 +331,19 @@ pub const IBCMODULE: Item<Addr> = Item::new("ibc_module");
 /// composite keys instead of a struct to avoid having to implement the
 /// PrimaryKey trait
 pub const RATE_LIMIT_TRACKERS: Map<(String, String), Vec<RateLimit>> = Map::new("flow");
+
+
+/// Indicates accounts that can bypass a rate limit for a specific IBC Channel + denom, and the amount that can be sent
+/// 
+/// maps (ibc_channel, denom) => sender => amount 
+pub const TEMPORARY_RATE_LIMIT_BYPASS: Map<(String, String), HashMap<String, Uint256>> = Map::new("bypass");
+
+/// BypassQueue is a workaround for the `Map` storage type not support
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct BypassQueue {
+    pub entries: HashMap<String, Uint256>
+}
+
 
 #[cfg(test)]
 pub mod tests {

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/sudo.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/sudo.rs
@@ -63,7 +63,6 @@ pub fn try_transfer(
     let mut trackers = RATE_LIMIT_TRACKERS
         .may_load(deps.storage, path.into())?
         .unwrap_or_default();
-    let mut bypass_queue = TEMPORARY_RATE_LIMIT_BYPASS.may_load(deps.storage, path.into())?.unwrap_or_default();
 
     let not_configured = trackers.is_empty() && any_trackers.is_empty();
 
@@ -87,6 +86,8 @@ pub fn try_transfer(
         }
     }
     {
+        let mut bypass_queue = TEMPORARY_RATE_LIMIT_BYPASS.may_load(deps.storage, path.into())?.unwrap_or_default();
+
         let sender = sender.to_string();
         // serves two purposes:
         //  1) when Some, indicates an address was eligible for bypass

--- a/x/ibc-rate-limit/contracts/rate-limiter/src/utils.rs
+++ b/x/ibc-rate-limit/contracts/rate-limiter/src/utils.rs
@@ -1,0 +1,71 @@
+use cosmwasm_std::{Timestamp, Uint256};
+
+use crate::state::{Quota, RateLimit};
+
+/// returns a percentage of the channel_value
+pub fn percentage_of_channel_value(channel_value: Uint256, percentage: u8) -> Option<Uint256> {
+    if percentage > 100 {
+        return None;
+    }
+    Some(channel_value * Uint256::from_u128(percentage as u128) / Uint256::from_u128(100))
+}
+
+/// given an array of rate limits, search and return the channel value of
+/// the first quota to end within the next 248 hours
+pub fn parse_first_daily_quota_channel_value(
+    rate_limits: &[RateLimit],
+    now: Timestamp,
+) -> Option<Uint256> {
+    for rate_limit in rate_limits {
+        // currently we are checking if the period is within the next 24 hours
+        // todo: consider if this is the right approach
+        if now.plus_seconds(86400) >= rate_limit.flow.period_end {
+            // return channel_value instead of full struct to leverage copy_type
+            return rate_limit.quota.channel_value;
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod test {
+    use cosmwasm_std::Timestamp;
+
+    use crate::state::{Flow, Quota};
+    const START_TIME: Timestamp = Timestamp::from_seconds(1700553596);
+    use super::*;
+    fn new_rate_limit(value: Option<u128>, end_time: Timestamp) -> RateLimit {
+        RateLimit {
+            quota: Quota {
+                channel_value: if let Some(value) = value {
+                    Some(Uint256::from_u128(value))
+                } else {
+                    None
+                },
+                name: Default::default(),
+                max_percentage_recv: 0,
+                max_percentage_send: 0,
+                duration: 0,
+            },
+            flow: Flow {
+                inflow: Uint256::zero(),
+                outflow: Uint256::zero(),
+                period_end: end_time,
+            },
+        }
+    }
+    #[test]
+    fn test_percentage_of_channel_value() {
+        let rate_limit_1 = new_rate_limit(Some(1_000_000_000), START_TIME.plus_seconds(86400));
+        let rate_limit_2 = new_rate_limit(Some(25_000_000_000), START_TIME.plus_seconds(86400 * 2));
+        let quota = parse_first_daily_quota_channel_value(
+            &[rate_limit_1.clone(), rate_limit_2.clone()],
+            START_TIME,
+        );
+        println!("{:#?}", quota);
+        assert_eq!(rate_limit_1.quota.channel_value, quota);
+        let percent =
+            percentage_of_channel_value(rate_limit_1.quota.channel_value.unwrap(), 25).unwrap();
+        assert_eq!(percent, Uint256::from_u128(250000000));
+    }
+}


### PR DESCRIPTION
# Overview

Adds a POC for implementation of dual queue ibc rate limits, allowing authorized  addresses to grant an address the ability to bypass rate limit evaluation up to a specific value.

# Specification

* An address can be granted the ability to send up to X tokens which bypass rate limit evaluation on a given channel+denom
* The queue is single use such that any transfer which triggers a rate limit bypass removes the bypass
* The `undo_X` functionality is a bit tricky to handle with the addition of the bypass queue so this has been omitted for now
* `Intents` allow senders to declare an amount of assets  to transfer that will bypass rate limit evaluation after a 24 hour period has elapsed since intent submission. It is a one time bypass and the transfer must send the exact amount of tokens.
* Intents can be removed before they are consumed
* Intent and Bypass functions are limited to invocation from the ibc or gov modules only

# For Osmosis Team

* What thresholds should be set for the bypass usage?

## Possible Future Improvements

One possible improvement would be to automatically add 24 hour delays to transfers above a certain threshold. When delayed the assets being transferred can be held by the rate limit contract until the delay period is over and the transfer is finalized.

However I don't believe it would be possible to integrate such functionality into the current ibc middleware implementation so it's likely a v2 would need to be written.

# Notes

* The `cosmwasm_storage` crate does not seem to support nested map serialization for state key-value entries
* Might be worth switching from the current vector which stores rate limit bypass permissions to the `dequeue` type? See the following error message for the error triggered when attempting to serialize nested maps

```
/home/solidity/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-json-wasm-0.4.1/src/ser/mod.rs:403:9:
internal error: entered unreachable code
```
